### PR TITLE
Add an specific length for every datatype

### DIFF
--- a/databaseSQL/procedures/p_addUserArgs.sql
+++ b/databaseSQL/procedures/p_addUserArgs.sql
@@ -1,7 +1,7 @@
 DELIMITER $$
-CREATE PROCEDURE p_addUSerArgs(email CHAR, U_name CHAR, nickname CHAR, U_password CHAR)
+CREATE PROCEDURE p_addUSerArgs(email CHAR(40), U_name CHAR(20), nickname CHAR(40), U_password CHAR(60))
     BEGIN
-        INSERT INTO User(
+        INSERT INTO user(
                     usr_email,
                     usr_name,
                     usr_nickname,


### PR DESCRIPTION
Resolves #2

Debido a que los tipos de datos son CHAR, esto quiere decir que su longitud es fija y al contrario de VARCHAR, si un valor no llena la longitud de la variable, este se llena con espacios. Al no especificar la longitud de las variables que pasamos como argumentos su longitud predeterminada es 1, por lo tanto cualquier valor mayor a un carácter generaba un error.